### PR TITLE
Add `baseURI` as component prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,3 +66,4 @@ export const query = graphql`
 | `blurryPlaceholder`       | `bool`   | Would you like to display a blurry placeholder for your loading image? Defaults to `true`. |
 | `backgroundColor`       | `string\|bool`   | Set a colored background placeholder. If true, uses "lightgray" for the color. You can also pass in any valid color string. |
 | `onLoad`                | `func`           | A callback that is called when the full-size image has loaded.                                                              |
+| `baseURI`               | `string`         | Set the base src from where the images are requested. Base URI Defaults to `https://media.graphcms.com`                     |

--- a/src/index.js
+++ b/src/index.js
@@ -6,8 +6,6 @@ if (typeof window !== 'undefined') {
   require('intersection-observer')
 }
 
-const baseURI = 'https://media.graphcms.com'
-
 // Cache if we've intersected an image before so we don't
 // lazy-load & fade in on subsequent mounts.
 const imageCache = {}
@@ -79,7 +77,7 @@ const resizeImage = ({ width, height, fit }) =>
 
 const compressAndWebp = webp => `${webp ? 'output=format:webp/' : ''}compress`
 
-const constructURL = (handle, withWebp) => resize => transforms =>
+const constructURL = (handle, withWebp, baseURI) => resize => transforms =>
   [
     baseURI,
     resize,
@@ -190,13 +188,14 @@ class GraphImage extends React.Component {
       transforms,
       blurryPlaceholder,
       backgroundColor,
-      fadeIn
+      fadeIn,
+      baseURI
     } = this.props
 
     if (width && height && handle) {
       // unify after webp + blur resolved
-      const srcBase = constructURL(handle, withWebp)
-      const thumbBase = constructURL(handle, false)
+      const srcBase = constructURL(handle, withWebp, baseURI)
+      const thumbBase = constructURL(handle, false, baseURI)
 
       // construct the final image url
       const sizedSrc = srcBase(resizeImage({ width, height, fit }))
@@ -288,20 +287,21 @@ class GraphImage extends React.Component {
 }
 
 GraphImage.defaultProps = {
-  title: '',
-  alt: '',
-  className: '',
-  outerWrapperClassName: '',
+  title: "",
+  alt: "",
+  className: "",
+  outerWrapperClassName: "",
   style: {},
-  fit: 'crop',
+  fit: "crop",
   maxWidth: 800,
   withWebp: true,
   transforms: [],
   blurryPlaceholder: true,
-  backgroundColor: '',
+  backgroundColor: "",
   fadeIn: true,
-  onLoad: null
-}
+  onLoad: null,
+  baseURI: 'https://media.graphcms.com'
+};
 
 GraphImage.propTypes = {
   title: PropTypes.string,
@@ -325,7 +325,8 @@ GraphImage.propTypes = {
   onLoad: PropTypes.func,
   blurryPlaceholder: PropTypes.bool,
   backgroundColor: PropTypes.oneOfType([PropTypes.string, PropTypes.bool]),
-  fadeIn: PropTypes.bool
+  fadeIn: PropTypes.bool,
+  baseURI: PropTypes.string
 }
 
 export default GraphImage

--- a/src/index.js
+++ b/src/index.js
@@ -108,7 +108,7 @@ const srcSet = (srcBase, srcWidths, transforms) =>
   srcWidths
     .map(
       width =>
-        `${srcBase([`resize=w:${width},fit:crop`])(transforms)} ${width}w`
+        `${srcBase([`resize=w:${Math.floor(width)},fit:crop`])(transforms)} ${Math.floor(width)}w`
     )
     .join(',\n')
 

--- a/src/index.js
+++ b/src/index.js
@@ -287,21 +287,21 @@ class GraphImage extends React.Component {
 }
 
 GraphImage.defaultProps = {
-  title: "",
-  alt: "",
-  className: "",
-  outerWrapperClassName: "",
+  title: '',
+  alt: '',
+  className: '',
+  outerWrapperClassName: '',
   style: {},
-  fit: "crop",
+  fit: 'crop',
   maxWidth: 800,
   withWebp: true,
   transforms: [],
   blurryPlaceholder: true,
-  backgroundColor: "",
+  backgroundColor: '',
   fadeIn: true,
   onLoad: null,
   baseURI: 'https://media.graphcms.com'
-};
+}
 
 GraphImage.propTypes = {
   title: PropTypes.string,


### PR DESCRIPTION
We have the case where we need to serve our assets from a cache layer and as the `baseURL` is declare as a `const` in the component we couldn't use it in our production environment.
Also, there are some cases where the _Filestack_ query applied to the images has a float number and is not supported. In order to save those cases, I added a `Math.floor` to it.